### PR TITLE
Fixing invalid host problem

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,5 +1,4 @@
 instrumentation:
     excludes:
         - spec/**/*.js
-        - lib/index.js
     include-all-sources: true

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Example:
                                     // Defaults to true.
     };
 
-    var shelfLib = require("shelf-lib")("<URL where pyshelf is hosted>", libOptions);
+    var shelfLib = require("shelf-lib")("<URL where shelf is hosted>", libOptions);
 
 
 Reference Creation
@@ -104,8 +104,8 @@ To download the contents and receive it in a variable:
 
 To upload an artifact from a file:
 
-    artifact.downloadToFile("./file-with-artifact-contents.txt").then((downloadLocation) => {
-        console.log("Downloaded contents to: " + downloadLocation);
+    artifact.uploadFromFile("./file-with-artifact-contents.txt").then((uploadLocation) => {
+        console.log("Uploaded contents to: " + downloadLocation);
     }, (err) => {
         console.log("Hit an error: " + err);
     });
@@ -216,3 +216,28 @@ Finally, you can perform the search with your constructed parameters:
     }, (err) => {
         console.log("Hit an error: " + err);
     });
+
+
+Errors
+------
+
+Shelf Lib will reject with special `ShelfError` errors. These inherit from `Error` so they can either be treated generically or if you would like to programmatically code against specific errors you can use the `error` and `ShelfError` properties on the Shelf Lib constructor. For example
+
+    var artifact, shelfLibConstructor, shelfLib, ref;
+
+    shelfLibConstructor = require("shelf-lib");
+    shelfLib = shelfLibConstructor("https://api.shelf.com");
+    ref = shelfLib.initReference("fake", "INVALID_TOKEN");
+    artifact = ref.initArtifact("/fake/path");
+
+    artifact.upload("fake contents").then(() => {
+        console.log("Everything uploaded fine.");
+    }, (err) => {
+        if (err.code == shelfLibConstructor.error.UNAUTHORIZED) {
+            console.log("Our token was invalid");
+        } else {
+            throw err;
+        }
+    });
+
+For more information see the [error module](https://github.com/not-nexus/shelf-lib-js/blob/master/lib/error.js).

--- a/lib/container.js
+++ b/lib/container.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = (host, libOptions) => {
+module.exports = (error, host, ShelfError, libOptions) => {
     var container, Dizzy, moduleDefs;
 
     Dizzy = require("dizzy");
@@ -14,6 +14,8 @@ module.exports = (host, libOptions) => {
     container.register("libOptions", libOptions);
     container.register("logLevel", libOptions.logLevel);
     container.register("host", host);
+    container.register("ShelfError", ShelfError);
+    container.register("error", error);
 
     // 3rd party libraries.
     // The key is the name in the container, the value is the name
@@ -39,13 +41,11 @@ module.exports = (host, libOptions) => {
         Artifact: "./artifact",
         ArtifactSearch: "./artifact-search",
         dateService: "./date-service",
-        error: "./error",
         logger: "./logger",
         Metadata: "./metadata",
         Reference: "./reference",
         requestOptions: "./request-options",
-        responseHandler: "./response-handler",
-        ShelfError: "./shelf-error"
+        responseHandler: "./response-handler"
     };
     Object.keys(moduleDefs).forEach((moduleKey) => {
         container.register(moduleKey, moduleDefs[moduleKey]).fromModule(__dirname).asFactory().cached();

--- a/lib/error.js
+++ b/lib/error.js
@@ -13,6 +13,7 @@ module.exports = () => {
         NOT_FOUND: "resource_not_found",
         TIMEOUT: "ESOCKETTIMEDOUT",
         UNAUTHORIZED: "permission_denied",
+        INVALID_HOST_PREFIX: "invalid_host_prefix",
         UNKNOWN: "UNKNOWN"
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,34 @@
 "use strict";
+var error, ShelfError;
 
-module.exports = (host, libOptions) => {
-    var container, error, logger, Reference, ShelfError, shelfLib;
+ShelfError = require("./shelf-error")();
+error = require("./error")();
 
-    // If host doesn't start with "http://" or "https://", throw an error.
-    if (!/^http(|s):\/\//.test(host)) {
-        throw new ShelfError("Shelf host must start with \"http://\" or \"https://\"");
-    }
+/**
+ * @typedef {Object} shelfLib
+ * @property {initReference} initReference
+ */
+
+/**
+ * @typedef {Function} initReference
+ * @param {string} refName - The reference name is how to refer to a
+ * storage space.
+ * @param {string} token - The shelf authentication token.
+ * @return {Reference}
+ */
+
+/**
+ * Factory for creating a shelf library. It is specific to a host
+ * and a few other configuration options.
+ *
+ * @property {ShelfError} ShelfError
+ * @property {lib/error} error
+ * @param {string} hostPrefix - The combination of the protocol and the host.
+ * @param {Object} libOptions
+ * @return {shelfLib}
+ */
+function shelfLibFactory(hostPrefix, libOptions) {
+    var container, logger, Reference, shelfLib;
 
     // libOptions is set to an empty object by defualt.
     // The user may supply additional options as needed.
@@ -38,9 +60,14 @@ module.exports = (host, libOptions) => {
     }
 
     // Load the dependency injection container.
-    container = require("./container")(host, libOptions);
+    container = require("./container")(error, hostPrefix, ShelfError, libOptions);
+
+    // If host doesn't start with "http://" or "https://", throw an error.
+    if (!/^http(|s):\/\//.test(hostPrefix)) {
+        throw new ShelfError("Shelf host must start with \"http://\" or \"https://\"", error.INVALID_HOST_PREFIX);
+    }
+
     logger = container.resolve("logger");
-    error = container.resolve("error");
     Reference = container.resolve("Reference");
     shelfLib = {};
     shelfLib.error = error;
@@ -60,4 +87,8 @@ module.exports = (host, libOptions) => {
     };
 
     return shelfLib;
-};
+}
+
+shelfLibFactory.ShelfError = ShelfError;
+shelfLibFactory.error = error;
+module.exports = shelfLibFactory;

--- a/spec/lib/container.spec.js
+++ b/spec/lib/container.spec.js
@@ -1,4 +1,8 @@
 "use strict";
+var error, ShelfError;
+
+error = require("../../lib/error")();
+ShelfError = require("../../lib/shelf-error")();
 
 describe("lib/container", () => {
     var container, host, libOptions;
@@ -8,7 +12,7 @@ describe("lib/container", () => {
         logLevel: "info"
     };
     beforeEach(() => {
-        container = require("../../lib/container")(host, libOptions);
+        container = require("../../lib/container")(error, host, ShelfError, libOptions);
     });
     it("returns an object", () => {
         expect(container).toEqual(jasmine.any(Object));

--- a/spec/lib/index.spec.js
+++ b/spec/lib/index.spec.js
@@ -1,0 +1,35 @@
+"use strict";
+
+describe("lib/index", () => {
+    var libConstructor;
+
+    libConstructor = require("../..");
+    it("fails with an invalid host prefix", () => {
+        try {
+            libConstructor("lol");
+            jasmine.fail("Should have thrown an exception");
+        } catch (err) {
+            expect(err.code).toEqual(libConstructor.error.INVALID_HOST_PREFIX);
+        }
+    });
+    it("still works when providing libOptions", () => {
+        var lib, libOptions;
+
+        libOptions = {
+            strictHostCheck: false,
+            logLevel: "info",
+            timeoutDuration: 5
+        };
+        lib = libConstructor("https://api.shelf.com", libOptions);
+        expect(lib.initReference).toEqual(jasmine.any(Function));
+    });
+    describe("initReference", () => {
+        it("creates a Reference", () => {
+            var lib, ref;
+
+            lib = libConstructor("https://api.shelf-qa.com");
+            ref = lib.initReference("fakeStorage", "abc123");
+            expect(ref.constructor.name).toBe("Reference");
+        });
+    });
+});


### PR DESCRIPTION
If an invalid host was provided, it would try to throw an error that
was not yet defined (ShelfError).

Along with this I noticed we were not running coverage on index which
is why a test hadn't caught this.

Also changed where error stuff was stored. It COULD go on the shelfLib
but then you wouldn't be able to use error.INVALID_HOST_PREFIX since you
would not yet have access to a shelfLib.