### PR TITLE
Required for uploading very large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The second parameter when requiring the library is an object holding various opt
 
 * `logLevel` - Sets the desired amount of logging. Values can be: "info", "debug", or "warning". The value defaults to "warning". WARNING: If the logLevel is set to "debug", the logger will log your Shelf authentication token. Log with "debug" at your own peril.
 * `strictHostCheck` - Turns off request strictHostCheck. This defaults to `true`.
-* `timeoutDuration` - Sets the amount of time in milliseconds before requests timeout. This defaults to 60000.
+* `timeoutDuration` - Sets the amount of time in milliseconds before requests timeout. This defaults to 300000 (five minutes).
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 shelf-lib-js
 ============
 
+[![Build Status](https://travis-ci.org/not-nexus/shelf-lib-js.svg?branch=master)](https://travis-ci.org/not-nexus/shelf-lib-js)
+[![codecov.io](https://codecov.io/github/not-nexus/shelf-lib-js/coverage.svg?branch=master)](https://codecov.io/github/not-nexus/shelf-lib-js?branch=master)
 
 Introduction
 ------------

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,12 +51,12 @@ function shelfLibFactory(hostPrefix, libOptions) {
         libOptions.logLevel = "warning";
     }
 
-    // timeoutDuration is set to 60000 (one minute) by default. The thought
+    // timeoutDuration is set to 300000 (five minute) by default. The thought
     // behind this is just setting it to something sort of long,
     // in case Shelf is under a large load.
     // If it is set, it will overrides the default timeout time.
     if (!libOptions.timeoutDuration) {
-        libOptions.timeoutDuration = 60000;
+        libOptions.timeoutDuration = 300000;
     }
 
     // Load the dependency injection container.


### PR DESCRIPTION
from a AWS's network. The exact reason is still unknown to me. It
    appears that what happens is the file gets done uploading to the
    shelf-api machine but then while it is waiting for a response
    (and shelf-api is uploading to S3) it goes on for longer than
    60 seconds without receiving or sending any packets. If we are
    supposed to see keep alive packets, we are not.
