### PR TITLE
fixing bug

### DIFF
--- a/lib/reference.js
+++ b/lib/reference.js
@@ -15,6 +15,7 @@ module.exports = (Artifact, ArtifactSearch, concatUri, dateService, error, logge
             }
             this.authToken = authToken;
             this.refName = refName;
+            this.shelfRequest = new ShelfRequest(this.authToken);
         }
 
 
@@ -33,7 +34,7 @@ module.exports = (Artifact, ArtifactSearch, concatUri, dateService, error, logge
             logger.debug(`In ${this.constructor.name}.initArtifact()`);
             uri = this.buildUrl(path);
 
-            return new Artifact(uri, new ShelfRequest(this.authToken));
+            return new Artifact(uri, this.shelfRequest);
         }
 
 
@@ -61,7 +62,7 @@ module.exports = (Artifact, ArtifactSearch, concatUri, dateService, error, logge
             logger.debug(`In ${this.constructor.name}.initArtifactWithTimestamp()`);
             uri = this.buildUrl(`${path}/${dateService.now()}`);
 
-            return new Artifact(uri, this.authToken);
+            return new Artifact(uri, this.shelfRequest);
         }
 
 
@@ -83,7 +84,7 @@ module.exports = (Artifact, ArtifactSearch, concatUri, dateService, error, logge
             logger.debug(`In ${this.constructor.name}.initSearch()`);
             uri = this.buildUrl(path);
 
-            return new ArtifactSearch(uri, new ShelfRequest(this.authToken));
+            return new ArtifactSearch(uri, this.shelfRequest);
         }
 
 

--- a/spec/lib/reference.spec.js
+++ b/spec/lib/reference.spec.js
@@ -62,6 +62,9 @@ describe("lib/reference", () => {
         it("passes the full URI along to the Artifact", () => {
             expect(artifact.uri).toBe(`${lib.uri.toString()}/2016-12-06T15:58:59.670Z`);
         });
+        it("passes along the ShelfRequest", () => {
+            expect(artifact.shelfRequest).toBe(instance.shelfRequest);
+        });
     });
     describe(".initSearch()", () => {
         it("instantiates a new ArtifactSearch", () => {


### PR DESCRIPTION
Where when initializing an artifact with initArtifactWithTimestamp
it would only pass along the authToken instead of the full
ShelfRequest object.